### PR TITLE
feat(surge-preview): improve behavior when the surge token is not set

### DIFF
--- a/.github/workflows/demo-surge-preview.yml
+++ b/.github/workflows/demo-surge-preview.yml
@@ -5,6 +5,7 @@ on:
     # To manage 'surge-preview' action teardown, add default event types + closed event type
     types: [opened, synchronize, reopened, closed]
     paths:
+      - '.github/workflows/demo-surge-preview.yml'
       - 'packages/surge-preview-tools/**/*'
 
 permissions:

--- a/.github/workflows/demo-surge-preview.yml
+++ b/.github/workflows/demo-surge-preview.yml
@@ -72,3 +72,28 @@ jobs:
           # The surge token is invalid, so the surge-preview should not run.
           # If it runs, the build will fail to detect that the surge-preview-tools has an issue.
           build: invalid_command
+
+  demo_not_set_token:
+    runs-on: ubuntu-22.04
+    env:
+      SURGE_TOKEN: ''
+    steps:
+      # only required to access to the local github actions
+      - uses: actions/checkout@v3
+      - uses: ./packages/surge-preview-tools
+        id: surge-preview-tools
+        with:
+          surge-token: ${{ env.SURGE_TOKEN }}
+      - name: Publish Demo preview
+        if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
+        id: publish_demo_preview_not_set_surge_token # used to have dedicated comment in the pull request
+        uses: afc163/surge-preview@v1
+        with:
+          surge_token: ${{ env.SURGE_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dist: site
+          failOnError: true
+          teardown: true
+          # The surge token is not set, so the surge-preview should not run.
+          # If it runs, the build will fail to detect that the surge-preview-tools has an issue.
+          build: invalid_command

--- a/packages/surge-preview-tools/dist/index.js
+++ b/packages/surge-preview-tools/dist/index.js
@@ -9096,8 +9096,13 @@ try {
 
   // the token must be set
   const surgeToken = core.getInput('surge-token');
-  core.setSecret(surgeToken);
-  const isSurgeTokenValid = checkLogin(surgeToken);
+  let isSurgeTokenValid = false
+  if (!surgeToken) {
+    core.info(`The surge token is not set`)
+  } else {
+    core.setSecret(surgeToken);
+    isSurgeTokenValid = checkLogin(surgeToken);
+  }
   core.info(`surge token valid? ${isSurgeTokenValid}`)
   core.setOutput("surge-token-valid", isSurgeTokenValid);
 

--- a/packages/surge-preview-tools/src/index.js
+++ b/packages/surge-preview-tools/src/index.js
@@ -14,8 +14,13 @@ try {
 
   // the token must be set
   const surgeToken = core.getInput('surge-token');
-  core.setSecret(surgeToken);
-  const isSurgeTokenValid = checkLogin(surgeToken);
+  let isSurgeTokenValid = false
+  if (!surgeToken) {
+    core.info(`The surge token is not set`)
+  } else {
+    core.setSecret(surgeToken);
+    isSurgeTokenValid = checkLogin(surgeToken);
+  }
   core.info(`surge token valid? ${isSurgeTokenValid}`)
   core.setOutput("surge-token-valid", isSurgeTokenValid);
 


### PR DESCRIPTION
Avoid extra warning log that was distracting and make think that something may go wrong.
Add a test job to check the logs in this case.

closes #35