### PR TITLE
ci: fix the 'create additional tags' workflow

### DIFF
--- a/.github/workflows/release-create-additional-tags.yml
+++ b/.github/workflows/release-create-additional-tags.yml
@@ -1,5 +1,5 @@
+# If the tag is v2.4.8 (for example) then this action will create 2 additional tags (v2 and v2.4) and push it.
 name: Create major and minor git tags
-description: If the tag is v2.4.8 (for example) then this action will create 2 additional tags (v2 and v2.4) and push it.
 
 on:
   push:


### PR DESCRIPTION
Remove extra the 'description' property which is not allowed. The workflow was invalid so the
execution failed.
Fix typo in file name