### PR TITLE
chore(pr-diff-checker): use local action instead of releases version

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -1,14 +1,16 @@
+# Demo/test the pr-diff-checker action
 name: Check PR content
 
 on: [pull_request]
 
 jobs:
   check_pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Check for forbidden string
     steps:
+      - uses: actions/checkout@v3 # access to the local action
       - name: Scan forbidden string
-        uses: bonitasoft/actions/packages/pr-diff-checker@v1.3.1
+        uses: ./packages/pr-diff-checker # local action
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           diffDoesNotContain: '["http://documentation.mydomain","link:"]'

--- a/packages/pr-diff-checker/action.yml
+++ b/packages/pr-diff-checker/action.yml
@@ -12,5 +12,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Used the latest available changes, including the ones provided in a Pull Request involving action changes to test the latest evolutions.

Also configure the action to run with Node 16. Running action with Node 12 is deprecated.

closes #36