### PR TITLE
feat(list-branches): remove deprecation warnings

### DIFF
--- a/.github/workflows/demo-list-branches.yml
+++ b/.github/workflows/demo-list-branches.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   list-branches:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       branches: ${{ steps.listBranches.outputs.branches }}
     steps:
@@ -18,12 +18,12 @@ jobs:
         uses: actions/checkout@v3
       - name: List branches on repository
         id: listBranches
-        uses: bonitasoft/actions/packages/list-branches@v1.3.1
+        uses: ./packages/list-branches # local action
         with:
           branches_list: ${{ inputs.branchesList }}
 
-  display_branch_name:
-    runs-on: ubuntu-20.04
+  checkout_branch_list:
+    runs-on: ubuntu-22.04
     needs: list-branches
     strategy:
       max-parallel: 2
@@ -37,5 +37,5 @@ jobs:
           ref: ${{ matrix.branch }}
           path: ./repo
           fetch-depth: '1'
-      - name: Display branche name
+      - name: Display branch name
         run: echo "I'm come form ${{ matrix.branch}} branch."

--- a/.github/workflows/demo-list-branches.yml
+++ b/.github/workflows/demo-list-branches.yml
@@ -38,4 +38,7 @@ jobs:
           path: ./repo
           fetch-depth: '1'
       - name: Display branch name
-        run: echo "I'm come form ${{ matrix.branch}} branch."
+        working-directory: ./repo
+        run: |
+          echo "I'm supposed to be the ${{ matrix.branch}} branch."
+          git status

--- a/.github/workflows/demo-list-branches.yml
+++ b/.github/workflows/demo-list-branches.yml
@@ -6,7 +6,7 @@ on:
       branchesList:
         description: 'Branches to run actions'
         required: true
-        default: "dev master release-7.14.*"
+        default: "main"
 
 jobs:
   list-branches:
@@ -15,7 +15,7 @@ jobs:
       branches: ${{ steps.listBranches.outputs.branches }}
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3 # access to the local action and list branches of this repository
       - name: List branches on repository
         id: listBranches
         uses: ./packages/list-branches # local action

--- a/packages/list-branches/README.md
+++ b/packages/list-branches/README.md
@@ -32,20 +32,20 @@ on:
 
 jobs:
   list-branches:
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-22.04
       outputs:
         branches: ${{ steps.listBranches.outputs.branches }}
       steps:
         - name: Checkout source
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
         - name: List branches on repository
           id: listBranches
-          uses: bonitasoft/actions/packages/list-branches@main
+          uses: bonitasoft/actions/packages/list-branches@v1
           with:
             branches_list: "dev master release-7.14.*"
 
   download-l10n-from-crowdin:
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-22.04
       needs: list-branches
       strategy:
         max-parallel: 1
@@ -54,7 +54,7 @@ jobs:
           branch: ${{ fromJSON(needs.listBranches.outputs.branches) }}
       steps:
         - name: Checkout Repo
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             ref: ${{ matrix.branch }}
             path: ./repo

--- a/packages/list-branches/action.yml
+++ b/packages/list-branches/action.yml
@@ -29,7 +29,8 @@ runs:
         
         # Create regex from input
         regex=$(jo -a ${{inputs.branches_list}} | jq -c 'map(. | tostring | . |= "^"+ . +"$") | join("|")' | tr -d \")
-        echo Computed branch list $(echo $json | jq -c --arg regex $regex 'map(select(test($regex)?))')
+        branchList=$(echo $json | jq -c --arg regex $regex 'map(select(test($regex)?))')
+        echo "Computed branch list: $branchList" 
         # set the output
-        echo "branches=$(echo $json | jq -c --arg regex $regex 'map(select(test($regex)?))')" >> $GITHUB_OUTPUT
+        echo "branches=$branchList" >> $GITHUB_OUTPUT
       id: extract_branches

--- a/packages/list-branches/action.yml
+++ b/packages/list-branches/action.yml
@@ -27,8 +27,9 @@ runs:
         # Create json object from branch list
         json=$(jo -a $branches | jq -c 'map(. | tostring)')
         
-        #Create regex from input
+        # Create regex from input
         regex=$(jo -a ${{inputs.branches_list}} | jq -c 'map(. | tostring | . |= "^"+ . +"$") | join("|")' | tr -d \")
         echo Computed branch list $(echo $json | jq -c --arg regex $regex 'map(select(test($regex)?))')
-        echo "::set-output name=branches::$(echo $json | jq -c --arg regex $regex 'map(select(test($regex)?))')"
+        # set the output
+        echo "branches=$(echo $json | jq -c --arg regex $regex 'map(select(test($regex)?))')" >> $GITHUB_OUTPUT
       id: extract_branches

--- a/packages/list-branches/action.yml
+++ b/packages/list-branches/action.yml
@@ -29,6 +29,6 @@ runs:
         
         #Create regex from input
         regex=$(jo -a ${{inputs.branches_list}} | jq -c 'map(. | tostring | . |= "^"+ . +"$") | join("|")' | tr -d \")
-        echo final $(echo $json | jq -c --arg regex $regex 'map(select(test($regex)?))')
+        echo Computed branch list $(echo $json | jq -c --arg regex $regex 'map(select(test($regex)?))')
         echo "::set-output name=branches::$(echo $json | jq -c --arg regex $regex 'map(select(test($regex)?))')"
       id: extract_branches


### PR DESCRIPTION
Remove deprecation warning: `The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/`

Other improvements
  - use local action in the demo workflow and run on Ubuntu 22
  - simplify the bash code used in the action
  - refresh the example in the README

covers #75

### Information

Tested with a workflow_dispatch using the branch of this PR: https://github.com/bonitasoft/actions/actions/runs/3395503761