### PR TITLE
ci: disable dependabot for JS actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,13 +14,3 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-
-  # Maintain dependencies for NPM
-  - package-ecosystem: "npm" 
-    directory: "/packages/pr-diff-checker" 
-    target-branch: main
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "chore"
-      include: "scope"


### PR DESCRIPTION
Currently, dependabot can only update a single action (i.e. a single folder). In addition, we are now reviewing and merging the Pull Requests it creates, so this is useless. We can update the dependencies from time to time instead.