### PR TITLE
feat(notify-slack): remove deprecation warnings

### DIFF
--- a/packages/notify-slack/action.yml
+++ b/packages/notify-slack/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Send a message to Slack channel
-      uses: slackapi/slack-github-action@v1.17.0
+      uses: slackapi/slack-github-action@v1.23.0
       with:
         channel-id: ${{ inputs.CHANNEL_ID}}
         payload: |


### PR DESCRIPTION
Bump slack-github-action from 1.17.0 to 1.23.0

covers #75 