### PR TITLE
feat: add the new `pr-title-conventional-commits` action

### DIFF
--- a/.github/workflows/pr-title-check-cc.yml
+++ b/.github/workflows/pr-title-check-cc.yml
@@ -14,5 +14,3 @@ jobs:
       - uses: actions/checkout@v3 # access to the local action
       - name: Check pull request title
         uses: ./packages/pr-title-conventional-commits # local action
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title-check-cc.yml
+++ b/.github/workflows/pr-title-check-cc.yml
@@ -13,3 +13,5 @@ jobs:
       - uses: actions/checkout@v3 # access to the local action
       - name: Check pull request title
         uses: ./packages/pr-title-conventional-commits # local action
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title-check-cc.yml
+++ b/.github/workflows/pr-title-check-cc.yml
@@ -2,8 +2,7 @@ name: Check Pull Request title
 
 on:
   pull_request:
-    # TODO remove synchronize (only to test action while implementing)
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened]
 
 jobs:
   pr-title:

--- a/.github/workflows/pr-title-check-cc.yml
+++ b/.github/workflows/pr-title-check-cc.yml
@@ -2,7 +2,8 @@ name: Check Pull Request title
 
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    # TODO remove synchronize (only to test action while implementing)
+    types: [opened, edited, reopened, synchronize]
 
 jobs:
   pr-title:

--- a/.github/workflows/pr-title-check-cc.yml
+++ b/.github/workflows/pr-title-check-cc.yml
@@ -1,0 +1,15 @@
+name: Check Pull Request title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  pr-title:
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
+    steps:
+      - uses: actions/checkout@v3 # access to the local action
+      - name: Check pull request title
+        uses: ./packages/pr-title-conventional-commits # local action

--- a/README.md
+++ b/README.md
@@ -7,18 +7,22 @@ Centralized repository providing GitHub Actions developed by Bonitasoft and used
 To use an action from this repository:
 
 ```yaml
- [...]
  steps:
    - name: Send message to Slack channel
      uses: bonitasoft/actions/packages/notify-slack@TAGNAME
-  [...]
 ```
 
 See the [actions list](packages) for more details
 
 ## Available tags
 
-**_TODO_**
+This repository follow [Semantic Versioning](https://semver.org/) and tags follow the `vX.Y.Z` patterns. In addition, the repository also provides tags for major and minor versions.
+
+For example
+- when releasing version `1.1.1`, the following tags are available: `v1.1.1`, `v1.1` and `v1`
+- then when releasing version `1.1.2`, a new `v1.1.2` tag is created. The `v1.1` and `v1` tags are updated to reference the tag of the newly released version.
+
+The list of tags is available in the [repository at GitHub](https://github.com/bonitasoft/actions/tags). 
 
 ## Release process
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ To use an action from this repository:
 
 See the [actions list](packages) for more details
 
+## Available tags
+
+**_TODO_**
+
 ## Release process
 
 Go to [GitHub release](https://github.com/bonitasoft/actions/releases)

--- a/packages/pr-title-conventional-commits/README.md
+++ b/packages/pr-title-conventional-commits/README.md
@@ -18,8 +18,12 @@ We want the commits to conform to `Conventional Commits`, so checking the PR tit
 Having a dedicated action also helps us to change the implementation transparently for the repositories that consumes it, without having
 to change every repository configuration if a better action emerges.
 
+In the past, Bonitasoft repositories were using various public actions and the checks done by these actions were not the same. We expect more consistency with this new action.
+For more details about the actions previously used and their limitations, see [bonita-documentation-site#422](https://github.com/bonitasoft/bonita-documentation-site/issues/422) and [#82](https://github.com/bonitasoft/actions/issues/82).
+
 This action uses [conventional-commits-pr-action](https://github.com/jef/conventional-commits-pr-action) under the hood. It set other defaults and
 provide more features.
+
 
 ## Usage
 
@@ -29,6 +33,7 @@ See [action.yml](./action.yml) for inputs and outputs.
 ### Permissions
 
 When setting the `comment` input to `true` or `auto` (default), set the `pull-requests` permission to `write`.
+
 
 ### Example
 
@@ -46,3 +51,4 @@ jobs:
       - name: Check Pull Request title
         uses: bonitasoft/actions/packages/pr-title-conventional-commits@TAGNAME
 ```
+

--- a/packages/pr-title-conventional-commits/README.md
+++ b/packages/pr-title-conventional-commits/README.md
@@ -44,6 +44,4 @@ jobs:
     steps:
       - name: Check Pull Request title
         uses: bonitasoft/actions/packages/pr-title-conventional-commits@TAGNAME
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/packages/pr-title-conventional-commits/README.md
+++ b/packages/pr-title-conventional-commits/README.md
@@ -1,0 +1,3 @@
+# pr-title-conventional-commits
+
+permissions

--- a/packages/pr-title-conventional-commits/README.md
+++ b/packages/pr-title-conventional-commits/README.md
@@ -1,3 +1,49 @@
-# pr-title-conventional-commits
+# pr-title-conventional-commits action
 
-permissions
+Check that the Pull Request title follows guidelines of [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
+
+Also has the ability to post a comment in the pull request conversation with examples.
+
+![image](https://user-images.githubusercontent.com/12074633/108867820-91325700-75c3-11eb-8820-4b55abe01c35.png)
+
+**Why do I need this action?**
+
+At Bonitasoft, we mainly use "squash and merge" for Pull Requests, and we often use the PR title as base of the merge commit (this can be suggested by GitHub by repository configuration).
+
+We want the commits to conform to `Conventional Commits`, so checking the PR title will be helpful.
+
+
+**Why developing a new action?**
+
+[conventional-commits-pr-action](https://github.com/jef/conventional-commits-pr-action) is great, but we want to have other defaults and more features.
+
+Having a dedicated action also helps us to change the implementation transparently for the repositories that consumes it, without having
+to change every repository configuration if a better action emerges.
+
+## Usage
+
+See [action.yml](./action.yml) for inputs and outputs.
+
+
+### Permissions
+
+When setting the `comment` input to `true` or `auto` (default), set the `pull-requests` permission to `write`.
+
+### Example
+
+```yaml
+on:
+  pull_request:
+    # trigger when the PR title changes
+    types: [opened, edited, reopened]
+jobs:
+  pr-title:
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
+    steps:
+      - name: Check Pull Request title
+        uses: bonitasoft/actions/packages/pr-title-conventional-commits@TAGNAME
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```

--- a/packages/pr-title-conventional-commits/README.md
+++ b/packages/pr-title-conventional-commits/README.md
@@ -52,3 +52,8 @@ jobs:
         uses: bonitasoft/actions/packages/pr-title-conventional-commits@TAGNAME
 ```
 
+In the example above, the workflow can also be triggered on the `pull_request_target` event. This allows to create comments when the Pull Request is created from a forked repository.
+
+Using `pull_request_target` is valid here as the workflow doesn't generate anything from the code, it only checks the Pull Request metadata , see
+- https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks
+- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

--- a/packages/pr-title-conventional-commits/README.md
+++ b/packages/pr-title-conventional-commits/README.md
@@ -2,7 +2,7 @@
 
 Check that the Pull Request title follows guidelines of [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
 
-Also has the ability to post a comment in the pull request conversation with examples.
+This action also has the ability to post a comment in the Pull Request conversation with examples, when the PR title is wrong.
 
 ![image](https://user-images.githubusercontent.com/12074633/108867820-91325700-75c3-11eb-8820-4b55abe01c35.png)
 
@@ -15,10 +15,11 @@ We want the commits to conform to `Conventional Commits`, so checking the PR tit
 
 **Why developing a new action?**
 
-[conventional-commits-pr-action](https://github.com/jef/conventional-commits-pr-action) is great, but we want to have other defaults and more features.
-
 Having a dedicated action also helps us to change the implementation transparently for the repositories that consumes it, without having
 to change every repository configuration if a better action emerges.
+
+This action uses [conventional-commits-pr-action](https://github.com/jef/conventional-commits-pr-action) under the hood. It set other defaults and
+provide more features.
 
 ## Usage
 

--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -3,7 +3,7 @@ description: Check that the Pull Request title follow the 'Conventional Commits'
 
 inputs:
   github-token:
-    description: ''
+    description: 'The token used to create Pull Request comment when the title does not follow requirements'
     required: true
     default: ${{ github.token }}
   comment:

--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -17,6 +17,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Log Pull Request Title
+      shell: bash
+      run: echo Checking PR Title:: "${{ github.event.title }}"
     - uses: jef/conventional-commits-pr-action@v1
       with:
         token: ${{ inputs.github-token }}

--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -31,24 +31,10 @@ runs:
         COMMENT_CONFIG: ${{ inputs.comment }}
       with:
         result-encoding: string
-        # TODO implement logic
-        # info from https://github.com/danger/danger-js/issues/918#issuecomment-645814203 that may help to detect that the PR is created from a fork
-        # const headRepoName = danger.github.pr.head.repo.full_name
-        #const baseRepoName = danger.github.pr.base.repo.full_name
-        #
-        #if headRepoName != baseRepoName {
-        #  // This is shown inline in the output
-        #  console.log("\033[1;31mRunning from a forked repo. Danger won't be able to post comments on the main repo unless GitHub Actions are enabled on the fork, too.\033[0m")
-        #
-        #  // This is shown inline in the output and also integrates with the GitHub
-        #  // Action reporting UI and produces a warning
-        #  console.log("##[warning]Running from a forked repo. Danger won't be able to post comments on the main repo unless GitHub Actions are enabled on the fork, too.\033[0m")
-        #}
         script: |
           const { COMMENT_CONFIG } = process.env
           core.info(`Original comment config: ${COMMENT_CONFIG}`);
-          //console.log(`Original comment config: ${COMMENT_CONFIG}`)
-          
+
           if(COMMENT_CONFIG == 'true') {
             core.info('Configured to always create Pull Request comment')
             return 'true';
@@ -59,36 +45,25 @@ runs:
             // conditions for 'auto':
             // event = pull_request AND not from a fork
             // event = pull_request_target          
-          
             const eventName = context.eventName
-            core.info(`Event name: ${eventName}`)
             if (eventName == 'pull_request_target') {
-              core.info('pull_request_target, so returns true')
+              core.info('pull_request_target event, so returns true')
               return 'true';
             } else if (eventName == 'pull_request') {
-              core.info('pull_request, detecting the origin of the Pull Request')
+              core.info('pull_request event, detecting the origin of the Pull Request')
               // Detect if the PR is created from a forked repository
               const head = context.payload?.pull_request?.head
               const isForkedRepository = head?.repo?.fork
-              //console.log('isForkedRepository', isForkedRepository);
               core.info(`Pull Request created from a forked repository? ${isForkedRepository}`);
-              core.info(`Configured to create Pull Request comment? ${isForkedRepository}`);
-              return isForkedRepository;
+              const usePrComment = !isForkedRepository
+              core.info(`Configured to create Pull Request comment? ${usePrComment}`);
+              return usePrComment;
             }
           }
+
           // Other case
           core.info('Configured to only log')
           return 'false';
-          
-          //let effectiveCommentSettings = COMMENT_CONFIG == 'true' || COMMENT_CONFIG == 'auto'
-          
-          //console.log(`effectiveCommentSettings: ${effectiveCommentSettings}`)
-          //console.log(context)
-          //console.log('PR owner', context.payload.pull_request.owner)
-          //console.log('PR head', context.payload.pull_request.head)
-          //console.log('Payload repository', context.payload.repository)
-          //console.log('repo', context.repo)
-          // return effectiveCommentSettings
     - uses: jef/conventional-commits-pr-action@v1
       with:
         token: ${{ inputs.github-token }}

--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
     - name: Log Pull Request Title
       shell: bash
-      run: echo Checking PR Title:: "${{ github.event.title }}"
+      run: echo Checking PR Title "${{ github.event.title }}"
     - uses: jef/conventional-commits-pr-action@v1
       with:
         token: ${{ inputs.github-token }}

--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -24,8 +24,8 @@ runs:
         PR_TITLE: ${{ github.event.pull_request.title }}
       shell: bash
       run: echo Checking PR Title "${PR_TITLE}"
-    - uses: actions/github-script@v6
-      name: Compute 'comment' settings
+    - name: Compute 'comment' settings
+      uses: actions/github-script@v6
       id: set-pr-comment-option
       env:
         COMMENT_CONFIG: ${{ inputs.comment }}
@@ -35,8 +35,11 @@ runs:
         script: |
           const { COMMENT_CONFIG } = process.env
           console.log(`Original comment config: ${COMMENT_CONFIG}`)
-          console.log(context)
-          return "true"
+          let effectiveCommentSettings = COMMENT_CONFIG == 'true' || COMMENT_CONFIG == 'auto'
+          console.log(`effectiveCommentSettings: ${effectiveCommentSettings}`)
+          //console.log(context)
+          // context.payload.pull_request
+          return effectiveCommentSettings
     - uses: jef/conventional-commits-pr-action@v1
       with:
         token: ${{ inputs.github-token }}

--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -5,6 +5,7 @@ inputs:
   github-token:
     description: ''
     required: true
+    default: ${{ github.token }}
   comment:
     description: >
       This input controls where the error messages and the fix suggestions are produced.
@@ -31,5 +32,5 @@ runs:
       with:
         token: ${{ inputs.github-token }}
         # TODO configure the comments
-        comment: false
+        comment: true
 

--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -58,6 +58,12 @@ runs:
           console.log('PR head', context.payload.pull_request.head)
           console.log('Payload repository', context.payload.repository)
           console.log('repo', context.repo)
+          
+          const head = context.payload?.pull_request?.head
+          const isForked = head?.repo?.fork
+          console.log('isForked', isForked);
+          
+          
           return effectiveCommentSettings
     - uses: jef/conventional-commits-pr-action@v1
       with:

--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -1,10 +1,11 @@
-name: Enforce Conventional Commits in Pull Request title
-description: TODO
+name: Check the Pull Request title
+description: Check that the Pull Request title follow the 'Conventional Commits' requirements
 
 runs:
   using: "composite"
   steps:
-    - shell: bash
-      run: echo
-
+    - uses: jef/conventional-commits-pr-action@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        # TODO configure the comments
 

--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -38,7 +38,7 @@ runs:
           let effectiveCommentSettings = COMMENT_CONFIG == 'true' || COMMENT_CONFIG == 'auto'
           console.log(`effectiveCommentSettings: ${effectiveCommentSettings}`)
           //console.log(context)
-          // context.payload.pull_request
+          console.log('owner', context.payload.pull_request.owner)
           return effectiveCommentSettings
     - uses: jef/conventional-commits-pr-action@v1
       with:

--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
     - name: Log Pull Request Title
       shell: bash
-      run: echo Checking PR Title "${{ github.event.title }}"
+      run: echo Checking PR Title "${{ github.event.pull_request.title }}"
     - uses: jef/conventional-commits-pr-action@v1
       with:
         token: ${{ inputs.github-token }}

--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -1,0 +1,10 @@
+name: Enforce Conventional Commits in Pull Request title
+description: TODO
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: echo
+
+

--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -46,25 +46,49 @@ runs:
         #}
         script: |
           const { COMMENT_CONFIG } = process.env
-          console.log(`Original comment config: ${COMMENT_CONFIG}`)
-          // conditions for 'auto':
-          // event = pull_request AND not from a fork
-          // event = pull_request_target
-          let effectiveCommentSettings = COMMENT_CONFIG == 'true' || COMMENT_CONFIG == 'auto'
+          core.info(`Original comment config: ${COMMENT_CONFIG}`);
+          //console.log(`Original comment config: ${COMMENT_CONFIG}`)
           
-          console.log(`effectiveCommentSettings: ${effectiveCommentSettings}`)
+          if(COMMENT_CONFIG == 'true') {
+            core.info('Configured to always create Pull Request comment')
+            return 'true';
+          }
+
+          if(COMMENT_CONFIG == 'auto') {
+            core.info('Auto settings, computing the actual configuration')
+            // conditions for 'auto':
+            // event = pull_request AND not from a fork
+            // event = pull_request_target          
+          
+            const eventName = context.eventName
+            core.info(`Event name: ${eventName}`)
+            if (eventName == 'pull_request_target') {
+              core.info('pull_request_target, so returns true')
+              return 'true';
+            } else if (eventName == 'pull_request') {
+              core.info('pull_request, detecting the origin of the Pull Request')
+              // Detect if the PR is created from a forked repository
+              const head = context.payload?.pull_request?.head
+              const isForkedRepository = head?.repo?.fork
+              //console.log('isForkedRepository', isForkedRepository);
+              core.info(`Pull Request created from a forked repository? ${isForkedRepository}`);
+              core.info(`Configured to create Pull Request comment? ${isForkedRepository}`);
+              return isForkedRepository;
+            }
+          }
+          // Other case
+          core.info('Configured to only log')
+          return 'false';
+          
+          //let effectiveCommentSettings = COMMENT_CONFIG == 'true' || COMMENT_CONFIG == 'auto'
+          
+          //console.log(`effectiveCommentSettings: ${effectiveCommentSettings}`)
           //console.log(context)
-          console.log('PR owner', context.payload.pull_request.owner)
-          console.log('PR head', context.payload.pull_request.head)
-          console.log('Payload repository', context.payload.repository)
-          console.log('repo', context.repo)
-          
-          const head = context.payload?.pull_request?.head
-          const isForked = head?.repo?.fork
-          console.log('isForked', isForked);
-          
-          
-          return effectiveCommentSettings
+          //console.log('PR owner', context.payload.pull_request.owner)
+          //console.log('PR head', context.payload.pull_request.head)
+          //console.log('Payload repository', context.payload.repository)
+          //console.log('repo', context.repo)
+          // return effectiveCommentSettings
     - uses: jef/conventional-commits-pr-action@v1
       with:
         token: ${{ inputs.github-token }}

--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -23,9 +23,9 @@ runs:
     - name: Log Pull Request Title
       env:
         # use env var as suggested in https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
-        TITLE: ${{ github.event.pull_request.title }}
+        PR_TITLE: ${{ github.event.pull_request.title }}
       shell: bash
-      run: echo Checking PR Title "$TITLE"
+      run: echo Checking PR Title "${PR_TITLE}"
 #    - name: Compute 'comment' settings
 #      uses:
     - uses: jef/conventional-commits-pr-action@v1

--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -1,11 +1,25 @@
 name: Check the Pull Request title
 description: Check that the Pull Request title follow the 'Conventional Commits' requirements
 
+inputs:
+  github-token:
+    description: ''
+    required: true
+  comment:
+    description: >
+      This input controls where the error messages and the fix suggestions are produced.
+      If 'true', create a Pull Request comment.
+      If 'false', add the messages in the GitHub Actions logs.
+      If 'auto', acts like 'false' for Pull Request created from forked repositories. Otherwise, acts like 'true'
+    required: true
+    default: 'auto'
+
 runs:
   using: "composite"
   steps:
     - uses: jef/conventional-commits-pr-action@v1
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ inputs.github-token }}
         # TODO configure the comments
+        comment: false
 

--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -17,8 +17,6 @@ inputs:
 
 runs:
   using: "composite"
-#  env:
-#    POST_PR_COMMENT: ${{}}
   steps:
     - name: Log Pull Request Title
       env:
@@ -26,11 +24,21 @@ runs:
         PR_TITLE: ${{ github.event.pull_request.title }}
       shell: bash
       run: echo Checking PR Title "${PR_TITLE}"
-#    - name: Compute 'comment' settings
-#      uses:
+    - uses: actions/github-script@v6
+      name: Compute 'comment' settings
+      id: set-pr-comment-option
+      env:
+        COMMENT_CONFIG: ${{ inputs.comment }}
+      with:
+        result-encoding: string
+        # TODO implement logic
+        script: |
+          const { COMMENT_CONFIG } = process.env
+          console.log(`Original comment config: ${COMMENT_CONFIG}`)
+          console.log(context)
+          return "true"
     - uses: jef/conventional-commits-pr-action@v1
       with:
         token: ${{ inputs.github-token }}
-        # TODO configure the comments
-        comment: true
+        comment: ${{ steps.set-pr-comment-option.outputs.result }}
 

--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -32,14 +32,31 @@ runs:
       with:
         result-encoding: string
         # TODO implement logic
+        # info from https://github.com/danger/danger-js/issues/918#issuecomment-645814203 that may help to detect that the PR is created from a fork
+        # const headRepoName = danger.github.pr.head.repo.full_name
+        #const baseRepoName = danger.github.pr.base.repo.full_name
+        #
+        #if headRepoName != baseRepoName {
+        #  // This is shown inline in the output
+        #  console.log("\033[1;31mRunning from a forked repo. Danger won't be able to post comments on the main repo unless GitHub Actions are enabled on the fork, too.\033[0m")
+        #
+        #  // This is shown inline in the output and also integrates with the GitHub
+        #  // Action reporting UI and produces a warning
+        #  console.log("##[warning]Running from a forked repo. Danger won't be able to post comments on the main repo unless GitHub Actions are enabled on the fork, too.\033[0m")
+        #}
         script: |
           const { COMMENT_CONFIG } = process.env
           console.log(`Original comment config: ${COMMENT_CONFIG}`)
+          // conditions for 'auto':
+          // event = pull_request AND not from a fork
+          // event = pull_request_target
           let effectiveCommentSettings = COMMENT_CONFIG == 'true' || COMMENT_CONFIG == 'auto'
+          
           console.log(`effectiveCommentSettings: ${effectiveCommentSettings}`)
           //console.log(context)
           console.log('PR owner', context.payload.pull_request.owner)
-          console.log('Payload repo', context.payload.repository)
+          console.log('PR head', context.payload.pull_request.head)
+          console.log('Payload repository', context.payload.repository)
           console.log('repo', context.repo)
           return effectiveCommentSettings
     - uses: jef/conventional-commits-pr-action@v1

--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -38,7 +38,9 @@ runs:
           let effectiveCommentSettings = COMMENT_CONFIG == 'true' || COMMENT_CONFIG == 'auto'
           console.log(`effectiveCommentSettings: ${effectiveCommentSettings}`)
           //console.log(context)
-          console.log('owner', context.payload.pull_request.owner)
+          console.log('PR owner', context.payload.pull_request.owner)
+          console.log('Payload repo', context.payload.repository)
+          console.log('repo', context.repo)
           return effectiveCommentSettings
     - uses: jef/conventional-commits-pr-action@v1
       with:

--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -16,10 +16,17 @@ inputs:
 
 runs:
   using: "composite"
+#  env:
+#    POST_PR_COMMENT: ${{}}
   steps:
     - name: Log Pull Request Title
+      env:
+        # use env var as suggested in https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+        TITLE: ${{ github.event.pull_request.title }}
       shell: bash
-      run: echo Checking PR Title "${{ github.event.pull_request.title }}"
+      run: echo Checking PR Title "$TITLE"
+#    - name: Compute 'comment' settings
+#      uses:
     - uses: jef/conventional-commits-pr-action@v1
       with:
         token: ${{ inputs.github-token }}


### PR DESCRIPTION
closes #82

### Tests done

The workflow defined in this repository calls the new action without any input (so the PR comment setting is 'auto').

This PR with [a wrong title](https://github.com/bonitasoft/actions/actions/runs/3470757294/jobs/5799358335). PR comment created https://github.com/bonitasoft/actions/pull/92#issuecomment-1314845752

```
Run ./packages/pr-title-conventional-commits
Run echo Checking PR Title "${PR_TITLE}"
Checking PR Title wip pr-title-conventional-commits
Run actions/github-script@v6
Original comment config: auto
Auto settings, computing the actual configuration
pull_request event, detecting the origin of the Pull Request
Pull Request created from a forked repository? false
Configured to create Pull Request comment? true
Run jef/conventional-commits-pr-action@v1
  with:
    token: ***
    comment: true
Error: pr linting failed. see pull request conversation.
```


PR #94 created from a forked repository with a wrong title, [only log](https://github.com/bonitasoft/actions/actions/runs/3471002926/jobs/5799923165)

```
Run ./packages/pr-title-conventional-commits
Run echo Checking PR Title "${PR_TITLE}"
Checking PR Title TEST create PR from for repo (test pr-title-cc)
Run actions/github-script@v6
Original comment config: auto
Auto settings, computing the actual configuration
pull_request event, detecting the origin of the Pull Request
Pull Request created from a forked repository? true
Configured to create Pull Request comment? false
Run jef/conventional-commits-pr-action@v1
  with:
    token: ***
    comment: false
Error: Error: pr linting failed.
```
