### PR TITLE
feat(surge-preview-tools): log debug message when check login fails

### DIFF
--- a/packages/surge-preview-tools/dist/index.js
+++ b/packages/surge-preview-tools/dist/index.js
@@ -9719,7 +9719,7 @@ const external_node_child_process_namespaceObject = require("node:child_process"
 
 
 const executeSurgeCliCmd = command => {
-  core.debug(`Running surge cli command with arguments ${command}`);
+  core.debug(`Running surge cli command with arguments "${command}"`);
   const commandElements = command.split(' ');
   let result = (0,external_node_child_process_namespaceObject.spawnSync)('npx',  ['surge', ...commandElements])
 
@@ -9730,7 +9730,10 @@ const executeSurgeCliCmd = command => {
   if (result.status === 0) {
     return stripAnsi(result.stdout.toString()).trim();
   }
-  throw new Error(`Surge command failed '${command}'. Details: ${result.stderr.toString()}`)
+  throw new Error(`Surge command failed '${command}'. Exit status: ${result.status}.
+Details:
+${result.stdout.toString()}
+${result.stderr.toString()}`)
 };
 
 const getSurgeCliVersion = () => {

--- a/packages/surge-preview-tools/dist/index.js
+++ b/packages/surge-preview-tools/dist/index.js
@@ -9730,11 +9730,13 @@ const getSurgeCliVersion = () => {
 }
 
 const checkLogin = surgeToken => {
+  let checkLoginOutput;
   try {
-    executeCmd(`${surgeCli} list --token ${surgeToken}`);
+    checkLoginOutput = executeCmd(`${surgeCli} list --token ${surgeToken}`);
     return true;
   } catch (e) {
-    core.debug(`Check login failed: ${e}`);
+    core.debug('Check login failed');
+    core.debug(checkLoginOutput);
     return false;
   }
 };

--- a/packages/surge-preview-tools/dist/index.js
+++ b/packages/surge-preview-tools/dist/index.js
@@ -9717,6 +9717,7 @@ const external_node_child_process_namespaceObject = require("node:child_process"
 
 
 
+
 const surgeCli = 'npx surge';
 
 const executeCmd = command => {
@@ -9725,15 +9726,15 @@ const executeCmd = command => {
 };
 
 const getSurgeCliVersion = () => {
-  const output = executeCmd(`${surgeCli} --version`);
-  return output;
+  return executeCmd(`${surgeCli} --version`);
 }
 
-const checkLogin = (surgeToken) => {
+const checkLogin = surgeToken => {
   try {
     executeCmd(`${surgeCli} list --token ${surgeToken}`);
     return true;
   } catch (e) {
+    core.debug(`Check login failed: ${e}`);
     return false;
   }
 };

--- a/packages/surge-preview-tools/src/surge-utils.js
+++ b/packages/surge-preview-tools/src/surge-utils.js
@@ -16,11 +16,13 @@ export const getSurgeCliVersion = () => {
 }
 
 export const checkLogin = surgeToken => {
+  let checkLoginOutput;
   try {
-    executeCmd(`${surgeCli} list --token ${surgeToken}`);
+    checkLoginOutput = executeCmd(`${surgeCli} list --token ${surgeToken}`);
     return true;
   } catch (e) {
-    core.debug(`Check login failed: ${e}`);
+    core.debug('Check login failed');
+    core.debug(checkLoginOutput);
     return false;
   }
 };

--- a/packages/surge-preview-tools/src/surge-utils.js
+++ b/packages/surge-preview-tools/src/surge-utils.js
@@ -2,6 +2,7 @@
 // released under the MIT license
 import stripAnsi from "strip-ansi";
 import {execSync} from 'node:child_process'
+import * as core from '@actions/core';
 
 const surgeCli = 'npx surge';
 
@@ -11,15 +12,15 @@ const executeCmd = command => {
 };
 
 export const getSurgeCliVersion = () => {
-  const output = executeCmd(`${surgeCli} --version`);
-  return output;
+  return executeCmd(`${surgeCli} --version`);
 }
 
-export const checkLogin = (surgeToken) => {
+export const checkLogin = surgeToken => {
   try {
     executeCmd(`${surgeCli} list --token ${surgeToken}`);
     return true;
   } catch (e) {
+    core.debug(`Check login failed: ${e}`);
     return false;
   }
 };

--- a/packages/surge-preview-tools/src/surge-utils.js
+++ b/packages/surge-preview-tools/src/surge-utils.js
@@ -5,7 +5,7 @@ import {spawnSync} from 'node:child_process'
 import * as core from '@actions/core';
 
 const executeSurgeCliCmd = command => {
-  core.debug(`Running surge cli command with arguments ${command}`);
+  core.debug(`Running surge cli command with arguments "${command}"`);
   const commandElements = command.split(' ');
   let result = spawnSync('npx',  ['surge', ...commandElements])
 
@@ -16,7 +16,10 @@ const executeSurgeCliCmd = command => {
   if (result.status === 0) {
     return stripAnsi(result.stdout.toString()).trim();
   }
-  throw new Error(`Surge command failed '${command}'. Details: ${result.stderr.toString()}`)
+  throw new Error(`Surge command failed '${command}'. Exit status: ${result.status}.
+Details:
+${result.stdout.toString()}
+${result.stderr.toString()}`)
 };
 
 export const getSurgeCliVersion = () => {


### PR DESCRIPTION
Re-running the workflow and activate the debug logs provides more details
```
 Surge cli version: v0.23.1
Computed preview url: https://bonitasoft-actions-demo_valid_token-pr-97.surge.sh
::add-mask::***
##[debug]Running surge cli command with arguments "list --token ***"
##[debug]STATUS 1
##[debug]STDOUT 
##[debug]   Error - Deployment endpoint temporarily unreachable
##[debug]
##[debug]
##[debug]STDERR 
##[debug]Check login failed: Error: Surge command failed 'list --token ***'. Exit status: 1.
##[debug]Details:
##[debug]
##[debug]   Error - Deployment endpoint temporarily unreachable
##[debug]
##[debug]
##[debug]
surge token valid? false
can run surge command? false
```