### PR TITLE
feat(surge-preview-tools): detect invalid domain name

### DIFF
--- a/.github/workflows/demo-surge-preview.yml
+++ b/.github/workflows/demo-surge-preview.yml
@@ -114,3 +114,29 @@ jobs:
           # The surge token is not set, so the surge-preview should not run.
           # If it runs, the build will fail to detect that the surge-preview-tools has an issue.
           build: invalid_command
+
+  demo_error_too_long_computed_surge_subdomain:  # the id is used by surge to generate the surge url, use a very long one to generate an error
+    runs-on: ubuntu-22.04
+    env:
+      SURGE_TOKEN: ${{ secrets.SURGE_TOKEN_DOC }}
+    steps:
+      # only required to access to the local github actions
+      - uses: actions/checkout@v3
+      - uses: ./packages/surge-preview-tools
+        id: surge-preview-tools
+        continue-on-error: true # we will verify the error in a later step
+        with:
+          surge-token: ${{ env.SURGE_TOKEN }}
+      - name: Detect error - too long computed surge subdomain
+        uses: actions/github-script@v6
+        env:
+          DETECTION_STATUS: ${{steps.surge-preview-tools.outcome}}
+        with:
+          script: |
+            const {DETECTION_STATUS} = process.env;
+            core.info(`Outcome of the 'surge-preview-tools' step is: ${DETECTION_STATUS}`);
+            if(DETECTION_STATUS === 'failure') {
+              core.info(`'surge-preview-tools' correctly detected that the computed surge subdomain is too long`);
+            } else {
+              core.setFailed(`'surge-preview-tools' should have detected that the computed surge subdomain is too long`)
+            }

--- a/packages/surge-preview-tools/dist/index.js
+++ b/packages/surge-preview-tools/dist/index.js
@@ -19636,7 +19636,14 @@ const checkIfDomainExist = async (url) => {
 const computeSurgeSubDomain = (repo, jobId, prNumber) => {
   const repoOwner = repo.owner.replace(/\./g, '-');
   const repoName = repo.repo.replace(/\./g, '-');
-  return `${repoOwner}-${repoName}-${jobId}-pr-${prNumber}`.toLowerCase();
+  const domain = `${repoOwner}-${repoName}-${jobId}-pr-${prNumber}`.toLowerCase();
+  if(domain.length > 63) {
+    throw new Error(`The computed surge subdomain is too long. It contains ${domain.length} characters, but it must contain a maximum of 63 characters.  
+Computed sub-domain: ${domain}
+In your workflow definition, try to use a shorter id for the job that runs this action.
+For more details, see https://github.com/bonitasoft/actions/issues/101`)
+  }
+  return domain;
 }
 
 /**

--- a/packages/surge-preview-tools/src/utils.mjs
+++ b/packages/surge-preview-tools/src/utils.mjs
@@ -26,7 +26,14 @@ export const checkIfDomainExist = async (url) => {
 export const computeSurgeSubDomain = (repo, jobId, prNumber) => {
   const repoOwner = repo.owner.replace(/\./g, '-');
   const repoName = repo.repo.replace(/\./g, '-');
-  return `${repoOwner}-${repoName}-${jobId}-pr-${prNumber}`.toLowerCase();
+  const domain = `${repoOwner}-${repoName}-${jobId}-pr-${prNumber}`.toLowerCase();
+  if(domain.length > 63) {
+    throw new Error(`The computed surge subdomain is too long. It contains ${domain.length} characters, but it must contain a maximum of 63 characters.  
+Computed sub-domain: ${domain}
+In your workflow definition, try to use a shorter id for the job that runs this action.
+For more details, see https://github.com/bonitasoft/actions/issues/101`)
+  }
+  return domain;
 }
 
 /**

--- a/packages/surge-preview-tools/src/utils.test.mjs
+++ b/packages/surge-preview-tools/src/utils.test.mjs
@@ -35,6 +35,14 @@ describe('computeSurgeSubDomain', () => {
   test('ensure lower case domain', () => {
     expect(computeSurgeSubDomain({owner: 'myOrga', repo: 'myRepo'}, 'jobNbr', '157')).toEqual('myorga-myrepo-jobnbr-pr-157');
   });
+  test('fail if the domain is invalid', () => {
+    expect(() => computeSurgeSubDomain({
+      owner: 'long-organization-name',
+      repo: 'long_repository_name'
+    }, 'very_very_long_job_id', '147875'))
+      // only test the beginning of the error
+      .toThrow('The computed surge subdomain is too long. It contains 75 characters, but it must contain a maximum of 63 characters.');
+  });
 });
 
 describe('computeSurgeDomain', () => {


### PR DESCRIPTION
closes #101 


## Integration test - workflow error detection

The `demo-surge-preview.yml` workflow has been updated to ensure the new use case is tested at high level.

![image](https://user-images.githubusercontent.com/27200110/212462323-0f7ed8bc-2047-4c77-b5fb-eba2724033c8.png)

Here is what happens if the action fails to detect the invalid sub-domain, for instance if a regression is introduced in the action distribution.

This has been simulated here to ensure the logic in the workflow is correct, by using a short job id. In this case, the action doesn't detect error on the sub-domain as it is actually valid:
- job id: `demo_error`
- sub-domain: `bonitasoft-actions-demo_error-pr-105` (36 characters)

![image](https://user-images.githubusercontent.com/27200110/212462497-0dccfb5b-efae-47ec-b8b5-14e97b45c4e3.png)
