### PR TITLE
test(slack): use a dedicated test channel in the GH workflow

### DIFF
--- a/.github/workflows/demo-slack-notification.yml
+++ b/.github/workflows/demo-slack-notification.yml
@@ -6,7 +6,7 @@ on:
       channel-id:
         description: 'The id of the channel to notify'
         required: true
-        default: CFD1SMX7V # rd-test-bots
+        default: C04S03S51UN # rd-test-bots
 
 jobs:
   notify-slack:

--- a/.github/workflows/demo-slack-notification.yml
+++ b/.github/workflows/demo-slack-notification.yml
@@ -6,7 +6,7 @@ on:
       channel-id:
         description: 'The id of the channel to notify'
         required: true
-        default: CFD1SMX7V-adapt
+        default: CFD1SMX7V # rd-test-bots
 
 jobs:
   notify-slack:

--- a/.github/workflows/demo-slack-notification.yml
+++ b/.github/workflows/demo-slack-notification.yml
@@ -6,7 +6,7 @@ on:
       channel-id:
         description: 'The id of the channel to notify'
         required: true
-        default: C04S03S51UN # rd-test-bots
+        default: C02J5M4JMK7 # slack-integration-test
 
 jobs:
   notify-slack:


### PR DESCRIPTION
To avoid spamming everybody, use a convenient test channel.