### PR TITLE
chore(notify-slack): bump slack-github-action from 1.23.0 to 1.24.0

### DIFF
--- a/packages/notify-slack/action.yml
+++ b/packages/notify-slack/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Send a message to Slack channel
-      uses: slackapi/slack-github-action@v1.23.0
+      uses: slackapi/slack-github-action@v1.24.0
       with:
         channel-id: ${{ inputs.CHANNEL_ID}}
         payload: |


### PR DESCRIPTION
### Notes

Tested with https://github.com/bonitasoft/actions/actions/runs/5089587604/jobs/9147401859
- `Run slackapi/slack-github-action@v1.24.0`
- message received in the test channel
