### PR TITLE
test: [POC] doc-site: fix the "push to production error" message

### DIFF
--- a/.github/workflows/demo-slack-notification.yml
+++ b/.github/workflows/demo-slack-notification.yml
@@ -23,5 +23,4 @@ jobs:
             - Add a :fire_extinguisher:if you take the action to resolve the conflicts (only one person is required) \n 
             - Add a :sweat_drops: when it’s done (and eventually a :party_parrot: ) \n \n
             More details on solving the conflicts locally <https://bonitasoft.atlassian.net/wiki/spaces/BS/pages/1181483014/Bonita+documentation+site+content+update#Bonita| there>
-        env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/demo-slack-notification.yml
+++ b/.github/workflows/demo-slack-notification.yml
@@ -18,13 +18,10 @@ jobs:
         with:
           CHANNEL_ID: ${{ inputs.channel-id }}
           MESSAGE: |
-            :heavy_check_mark: This is a test from the `${{github.repository}}` repository.
-
-            The workflow was triggered manually by `${{github.triggering_actor}}` as `${{github.actor}}`
-            ## The following is taken from the doc-site message
             :fire:  Propagating documentation upwards failed for repository *${{matrix.repo}}*. \n \n  
             @channel *We need someone* ! \n  
             - Add a :fire_extinguisher:if you take the action to resolve the conflicts (only one person is required) \n 
             - Add a :sweat_drops: when it’s done (and eventually a :party_parrot: ) \n \n
             More details on solving the conflicts locally <https://bonitasoft.atlassian.net/wiki/spaces/BS/pages/1181483014/Bonita+documentation+site+content+update#Bonita| there>
+        env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/demo-slack-notification.yml
+++ b/.github/workflows/demo-slack-notification.yml
@@ -21,4 +21,10 @@ jobs:
             :heavy_check_mark: This is a test from the `${{github.repository}}` repository.
 
             The workflow was triggered manually by `${{github.triggering_actor}}` as `${{github.actor}}`
+            ## The following is taken from the doc-site message
+            :fire:  Propagating documentation upwards failed for repository *${{matrix.repo}}*. \n \n  
+            @channel *We need someone* ! \n  
+            - Add a :fire_extinguisher:if you take the action to resolve the conflicts (only one person is required) \n 
+            - Add a :sweat_drops: when it’s done (and eventually a :party_parrot: ) \n \n
+            More details on solving the conflicts locally <https://bonitasoft.atlassian.net/wiki/spaces/BS/pages/1181483014/Bonita+documentation+site+content+update#Bonita| there>
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/demo-slack-notification.yml
+++ b/.github/workflows/demo-slack-notification.yml
@@ -18,9 +18,12 @@ jobs:
         with:
           CHANNEL_ID: ${{ inputs.channel-id }}
           MESSAGE: |
-            :fire:  Propagating documentation upwards failed for repository *${{matrix.repo}}*. \n \n  
-            @channel *We need someone* ! \n  
-            - Add a :fire_extinguisher:if you take the action to resolve the conflicts (only one person is required) \n 
-            - Add a :sweat_drops: when it’s done (and eventually a :party_parrot: ) \n \n
+            :fire:  Propagating documentation upwards failed for repository *${{matrix.repo}}*.
+
+
+            @channel *We need someone*!
+            - Add a :fire_extinguisher:if you take the action to resolve the conflicts (only one person is required)
+            - Add a :sweat_drops: when it’s done (and eventually a :party_parrot:)
+
             More details on solving the conflicts locally <https://bonitasoft.atlassian.net/wiki/spaces/BS/pages/1181483014/Bonita+documentation+site+content+update#Bonita| there>
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/packages/notify-slack/action.yml
+++ b/packages/notify-slack/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Send a message to Slack channel
-      uses: slackapi/slack-github-action@v1.24.0
+      uses: slackapi/slack-github-action@v1.23.0
       with:
         channel-id: ${{ inputs.CHANNEL_ID}}
         payload: |


### PR DESCRIPTION
**Only created to investigate https://github.com/bonitasoft/bonita-documentation-site/issues/563**

Not intended to be merged!


### Root cause analysis

The slack token was not correctly pass to the bonitasoft/actions. The env context was still set but the action expect it to be with an action input.
The documentation site currently use bonitasoft/actions@2.2.0 that uses slackapi/slack-github-action@v1.23.0.
The latest v1.24.0 slack action explicitly fails when the slack token is not correctly set

Run with commit c244cbf https://github.com/bonitasoft/actions/actions/runs/5089866920/jobs/9147993921
```
Run slackapi/slack-github-action@v1.24.0
  with:
    channel-id: C02J5M4JMK7
    payload: {
      "blocks": [
          {
              "type": "section",
              "text": {
                  "type": "mrkdwn",
                  "text": ":fire:  Propagating documentation upwards failed for repository **. \\n \\n  \n@channel *We need someone* ! \\n  \n- Add a :fire_extinguisher:if you take the action to resolve the conflicts (only one person is required) \\n \n- Add a :sweat_drops: when it’s done (and eventually a :party_parrot: ) \\n \\n\nMore details on solving the conflicts locally <https://bonitasoft.atlassian.net/wiki/spaces/BS/pages/1181483014/Bonita+documentation+site+content+update#Bonita| there>\n"
              }
          },
          {
              "type": "divider"
          },
          {
              "type": "section",
              "text": {
                  "type": "mrkdwn",
                  "text": "More details <https://github.com/bonitasoft/actions/actions/runs/5089866920?check_suite_focus=true| here>"
              }
          }
      ]
  }
  
  env:
    SLACK_BOT_TOKEN: 
Error: Error: Need to provide at least one botToken or webhookUrl
```


### Updated message

Message sent with the content of f9a7fed

![doc_site_push_production_error_slack_msg](https://github.com/bonitasoft/actions/assets/27200110/dde92949-5cbd-4103-a647-e2848c5f6759)




