### PR TITLE
chore: bump actions/github-script from 6 to 7

### DIFF
--- a/packages/pr-title-conventional-commits/action.yml
+++ b/packages/pr-title-conventional-commits/action.yml
@@ -25,7 +25,7 @@ runs:
       shell: bash
       run: echo Checking PR Title "${PR_TITLE}"
     - name: Compute 'comment' settings
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       id: set-pr-comment-option
       env:
         COMMENT_CONFIG: ${{ inputs.comment }}


### PR DESCRIPTION
This applies to the `pr-title-conventional-commits` action.
This requires Node 20 to run.