### PR TITLE
chore(surge-preview-tools): use advanced search when searching PR number with API

### DIFF
--- a/packages/surge-preview-tools/dist/index.js
+++ b/packages/surge-preview-tools/dist/index.js
@@ -33165,6 +33165,7 @@ async function getPrNumberByApiSearch(github_context, gitCommitSha) {
         advanced_search: true, // required to prepare forced usage. See https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more/
       };
       try {
+        const token = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('github-token', { required: true });
         const octokit = _actions_github__WEBPACK_IMPORTED_MODULE_1__.getOctokit(token);
         const result = await octokit.rest.search.issuesAndPullRequests(query);
         const pr = result.data.items.length > 0 && result.data.items[0];
@@ -33185,7 +33186,6 @@ try {
    * @returns prNumber
    */
   const getPrNumber = async (github_context) => {
-    const token = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('github-token', { required: true });
     const {payload} = github_context;
     const gitCommitSha =
     payload?.pull_request?.head?.sha ||

--- a/packages/surge-preview-tools/dist/index.js
+++ b/packages/surge-preview-tools/dist/index.js
@@ -33155,8 +33155,9 @@ __nccwpck_require__.r(__webpack_exports__);
 
 
 
+// TODO use debug logs
 async function getPrNumberByApiSearch(github_context, gitCommitSha) {
-      _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`Searching PR related to commit: ${gitCommitSha}`);
+      _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Searching PR related to commit: ${gitCommitSha}`);
       // Inspired by https://github.com/orgs/community/discussions/25220#discussioncomment-8697399
       const query = {
         q: `repo:${github_context.repo.owner}/${github_context.repo.repo} AND is:pr AND sha:${gitCommitSha}`,
@@ -33168,7 +33169,7 @@ async function getPrNumberByApiSearch(github_context, gitCommitSha) {
         const octokit = _actions_github__WEBPACK_IMPORTED_MODULE_1__.getOctokit(token);
         const result = await octokit.rest.search.issuesAndPullRequests(query);
         const pr = result.data.items.length > 0 && result.data.items[0];
-        _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`Found related pull_request: ${JSON.stringify(pr, null, 2)}`);
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Found related pull_request: ${JSON.stringify(pr, null, 2)}`);
         return pr ? pr.number : undefined;
       } catch (e) {
         // As mentioned in https://github.com/orgs/community/discussions/25220#discussioncomment-8971083
@@ -33191,20 +33192,22 @@ try {
     payload?.workflow_run?.head_sha;
 
     if (payload.number && payload.pull_request) {
-      _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`pull_request event, so retrieving the PR number from payload`);
+      _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`prNumber retrieved from pull_request ${payload.number}`);
+      // TODO temp to test when runnning on a PR
+      await getPrNumberByApiSearch(github_context, gitCommitSha);      
       return payload.number;
     } else {
-      _actions_core__WEBPACK_IMPORTED_MODULE_0__.info('Not a pull_request event, so doing an API search to get the PR number');
+      _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug('Not a pull_request, so doing a API search');
       return await getPrNumberByApiSearch(github_context, gitCommitSha);
     }
   }
 
   const surgeCliVersion = (0,_surge_utils__WEBPACK_IMPORTED_MODULE_2__/* .getSurgeCliVersion */ .re)();
   _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Surge cli version: ${surgeCliVersion}`);
-
+  
   const {job, payload} = _actions_github__WEBPACK_IMPORTED_MODULE_1__.context;
   const prNumber= await getPrNumber(_actions_github__WEBPACK_IMPORTED_MODULE_1__.context);
-  _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Retrieved PR number: ${prNumber}`);
+  _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Find PR number: ${prNumber}`);
   if(prNumber === undefined){
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed('No PR number found');
   }

--- a/packages/surge-preview-tools/dist/index.js
+++ b/packages/surge-preview-tools/dist/index.js
@@ -33165,6 +33165,7 @@ async function getPrNumberByApiSearch(github_context, gitCommitSha) {
         advanced_search: true, // required to prepare forced usage. See https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more/
       };
       try {
+        const octokit = _actions_github__WEBPACK_IMPORTED_MODULE_1__.getOctokit(token);
         const result = await octokit.rest.search.issuesAndPullRequests(query);
         const pr = result.data.items.length > 0 && result.data.items[0];
         _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Found related pull_request: ${JSON.stringify(pr, null, 2)}`);

--- a/packages/surge-preview-tools/dist/index.js
+++ b/packages/surge-preview-tools/dist/index.js
@@ -33155,9 +33155,8 @@ __nccwpck_require__.r(__webpack_exports__);
 
 
 
-// TODO use debug logs
 async function getPrNumberByApiSearch(github_context, gitCommitSha) {
-      _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Searching PR related to commit: ${gitCommitSha}`);
+      _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`Searching PR related to commit: ${gitCommitSha}`);
       // Inspired by https://github.com/orgs/community/discussions/25220#discussioncomment-8697399
       const query = {
         q: `repo:${github_context.repo.owner}/${github_context.repo.repo} AND is:pr AND sha:${gitCommitSha}`,
@@ -33169,7 +33168,7 @@ async function getPrNumberByApiSearch(github_context, gitCommitSha) {
         const octokit = _actions_github__WEBPACK_IMPORTED_MODULE_1__.getOctokit(token);
         const result = await octokit.rest.search.issuesAndPullRequests(query);
         const pr = result.data.items.length > 0 && result.data.items[0];
-        _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Found related pull_request: ${JSON.stringify(pr, null, 2)}`);
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`Found related pull_request: ${JSON.stringify(pr, null, 2)}`);
         return pr ? pr.number : undefined;
       } catch (e) {
         // As mentioned in https://github.com/orgs/community/discussions/25220#discussioncomment-8971083
@@ -33192,22 +33191,20 @@ try {
     payload?.workflow_run?.head_sha;
 
     if (payload.number && payload.pull_request) {
-      _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`prNumber retrieved from pull_request ${payload.number}`);
-      // TODO temp to test when runnning on a PR
-      await getPrNumberByApiSearch(github_context, gitCommitSha);      
+      _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`pull_request event, so retrieving the PR number from payload`);
       return payload.number;
     } else {
-      _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug('Not a pull_request, so doing a API search');
+      _actions_core__WEBPACK_IMPORTED_MODULE_0__.info('Not a pull_request event, so doing an API search to get the PR number');
       return await getPrNumberByApiSearch(github_context, gitCommitSha);
     }
   }
 
   const surgeCliVersion = (0,_surge_utils__WEBPACK_IMPORTED_MODULE_2__/* .getSurgeCliVersion */ .re)();
   _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Surge cli version: ${surgeCliVersion}`);
-  
+
   const {job, payload} = _actions_github__WEBPACK_IMPORTED_MODULE_1__.context;
   const prNumber= await getPrNumber(_actions_github__WEBPACK_IMPORTED_MODULE_1__.context);
-  _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Find PR number: ${prNumber}`);
+  _actions_core__WEBPACK_IMPORTED_MODULE_0__.info(`Retrieved PR number: ${prNumber}`);
   if(prNumber === undefined){
     _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed('No PR number found');
   }

--- a/packages/surge-preview-tools/src/index.js
+++ b/packages/surge-preview-tools/src/index.js
@@ -13,6 +13,7 @@ async function getPrNumberByApiSearch(github_context, gitCommitSha) {
         advanced_search: true, // required to prepare forced usage. See https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more/
       };
       try {
+        const octokit = github.getOctokit(token);
         const result = await octokit.rest.search.issuesAndPullRequests(query);
         const pr = result.data.items.length > 0 && result.data.items[0];
         core.info(`Found related pull_request: ${JSON.stringify(pr, null, 2)}`);

--- a/packages/surge-preview-tools/src/index.js
+++ b/packages/surge-preview-tools/src/index.js
@@ -3,6 +3,28 @@ import * as github from "@actions/github";
 import { checkLogin, getDeploys, getSurgeCliVersion } from "./surge-utils";
 import { checkIfDomainExist, computeSurgeDomain } from "./utils.mjs";
 
+// TODO use debug logs
+async function getPrNumberByApiSearch(github_context, gitCommitSha) {
+      core.info(`Searching PR related to commit: ${gitCommitSha}`);
+      // Inspired by https://github.com/orgs/community/discussions/25220#discussioncomment-8697399
+      const query = {
+        q: `repo:${github_context.repo.owner}/${github_context.repo.repo} AND is:pr AND sha:${gitCommitSha}`,
+        per_page: 1,
+        advanced_search: true, // required to prepare forced usage. See https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more/
+      };
+      try {
+        const result = await octokit.rest.search.issuesAndPullRequests(query);
+        const pr = result.data.items.length > 0 && result.data.items[0];
+        core.info(`Found related pull_request: ${JSON.stringify(pr, null, 2)}`);
+        return pr ? pr.number : undefined;
+      } catch (e) {
+        // As mentioned in https://github.com/orgs/community/discussions/25220#discussioncomment-8971083
+        // from time to time, you may get rate limit errors given search API seems to use many calls internally.
+        core.warning(`Unable to get the PR number with API search: ${e}`);
+      }
+}
+
+
 try {
   /**
    * Retrieve the PR number
@@ -11,32 +33,19 @@ try {
    */
   const getPrNumber = async (github_context) => {
     const token = core.getInput('github-token', { required: true });
-    const octokit = github.getOctokit(token);
     const {payload} = github_context;
     const gitCommitSha =
     payload?.pull_request?.head?.sha ||
     payload?.workflow_run?.head_sha;
 
     if (payload.number && payload.pull_request) {
-      core.debug(`prNumber retrieved from pull_request ${payload.number}`);      
+      core.debug(`prNumber retrieved from pull_request ${payload.number}`);
+      // TODO temp to test when runnning on a PR
+      await getPrNumberByApiSearch(github_context, gitCommitSha);      
       return payload.number;
     } else {
       core.debug('Not a pull_request, so doing a API search');
-      // Inspired by https://github.com/orgs/community/discussions/25220#discussioncomment-8697399
-      const query = {
-        q: `repo:${github_context.repo.owner}/${github_context.repo.repo} is:pr sha:${gitCommitSha}`,
-        per_page: 1,
-      };
-      try {
-        const result = await octokit.rest.search.issuesAndPullRequests(query);
-        const pr = result.data.items.length > 0 && result.data.items[0];
-        core.debug(`Found related pull_request: ${JSON.stringify(pr, null, 2)}`);
-        return pr ? pr.number : undefined;
-      } catch (e) {
-        // As mentioned in https://github.com/orgs/community/discussions/25220#discussioncomment-8971083
-        // from time to time, you may get rate limit errors given search API seems to use many calls internally.
-        core.warning(`Unable to get the PR number with API search: ${e}`);
-      }
+      return await getPrNumberByApiSearch(github_context, gitCommitSha);
     }
   }
 

--- a/packages/surge-preview-tools/src/index.js
+++ b/packages/surge-preview-tools/src/index.js
@@ -13,6 +13,7 @@ async function getPrNumberByApiSearch(github_context, gitCommitSha) {
         advanced_search: true, // required to prepare forced usage. See https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more/
       };
       try {
+        const token = core.getInput('github-token', { required: true });
         const octokit = github.getOctokit(token);
         const result = await octokit.rest.search.issuesAndPullRequests(query);
         const pr = result.data.items.length > 0 && result.data.items[0];
@@ -33,7 +34,6 @@ try {
    * @returns prNumber
    */
   const getPrNumber = async (github_context) => {
-    const token = core.getInput('github-token', { required: true });
     const {payload} = github_context;
     const gitCommitSha =
     payload?.pull_request?.head?.sha ||

--- a/packages/surge-preview-tools/src/index.js
+++ b/packages/surge-preview-tools/src/index.js
@@ -3,8 +3,9 @@ import * as github from "@actions/github";
 import { checkLogin, getDeploys, getSurgeCliVersion } from "./surge-utils";
 import { checkIfDomainExist, computeSurgeDomain } from "./utils.mjs";
 
+// TODO use debug logs
 async function getPrNumberByApiSearch(github_context, gitCommitSha) {
-      core.debug(`Searching PR related to commit: ${gitCommitSha}`);
+      core.info(`Searching PR related to commit: ${gitCommitSha}`);
       // Inspired by https://github.com/orgs/community/discussions/25220#discussioncomment-8697399
       const query = {
         q: `repo:${github_context.repo.owner}/${github_context.repo.repo} AND is:pr AND sha:${gitCommitSha}`,
@@ -16,7 +17,7 @@ async function getPrNumberByApiSearch(github_context, gitCommitSha) {
         const octokit = github.getOctokit(token);
         const result = await octokit.rest.search.issuesAndPullRequests(query);
         const pr = result.data.items.length > 0 && result.data.items[0];
-        core.debug(`Found related pull_request: ${JSON.stringify(pr, null, 2)}`);
+        core.info(`Found related pull_request: ${JSON.stringify(pr, null, 2)}`);
         return pr ? pr.number : undefined;
       } catch (e) {
         // As mentioned in https://github.com/orgs/community/discussions/25220#discussioncomment-8971083
@@ -39,20 +40,22 @@ try {
     payload?.workflow_run?.head_sha;
 
     if (payload.number && payload.pull_request) {
-      core.info(`pull_request event, so retrieving the PR number from payload`);
+      core.debug(`prNumber retrieved from pull_request ${payload.number}`);
+      // TODO temp to test when runnning on a PR
+      await getPrNumberByApiSearch(github_context, gitCommitSha);      
       return payload.number;
     } else {
-      core.info('Not a pull_request event, so doing an API search to get the PR number');
+      core.debug('Not a pull_request, so doing a API search');
       return await getPrNumberByApiSearch(github_context, gitCommitSha);
     }
   }
 
   const surgeCliVersion = getSurgeCliVersion();
   core.info(`Surge cli version: ${surgeCliVersion}`);
-
+  
   const {job, payload} = github.context;
   const prNumber= await getPrNumber(github.context);
-  core.info(`Retrieved PR number: ${prNumber}`);
+  core.info(`Find PR number: ${prNumber}`);
   if(prNumber === undefined){
     core.setFailed('No PR number found');
   }


### PR DESCRIPTION
Not using the advanced search is deprecated and generated a warning in the logs.

### Notes

Covers #146


## ✔️ Tests OK

https://github.com/bonitasoft/actions/actions/runs/14637302272/job/41071279898 on commit 4e775e2. See [logs_37611501083.zip](https://github.com/user-attachments/files/20087587/logs_37611501083.zip)

The following log show that there is no warning when executing the query. This is the sole purpose of the test.
The resulting PR number is wrong because the query is run with a wrong commit (the code using the query is only design to work when running from a workflow_run event whereas in this tests, the workflow runs from a pull_request event)

```
Run ./packages/surge-preview-tools
Surge cli version: v0.24.6
Searching PR related to commit: 4e775e28d98eb70c256227a8bb77804885c757ff
Found related pull_request: {
  "url": "https://api.github.com/repos/bonitasoft/actions/issues/149",
...
"score": 1
}
```
