### PR TITLE
ci: use ubuntu-22.04 in the "build doc site" workflow

### DIFF
--- a/.github/workflows/build-pr-actions-doc-site.yml
+++ b/.github/workflows/build-pr-actions-doc-site.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Previously, the workflow was using ubuntu-20.04 which generates an error because the runner is no longer available.