### PR TITLE
chore(rebranding): update bonitasoft.com domain references to ofelia.com

### DIFF
--- a/packages/doc-contribs/pr-antora-content-guidelines-checker/README.md
+++ b/packages/doc-contribs/pr-antora-content-guidelines-checker/README.md
@@ -36,7 +36,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }} // optional
           attributes-to-check: ':description:'
           files-to-check: 'adoc'
-          forbidden-pattern-to-check: 'https://documentation.bonitasoft.com, link:'
+          forbidden-pattern-to-check: 'https://documentation.ofelia.com, link:'
           steps-to-skip: ''
 ```
 


### PR DESCRIPTION
Replace bonitasoft.com domain URLs with ofelia.com equivalents. No logic changes. Part of the Bonitasoft → Ofelia rebranding.